### PR TITLE
Fix indentation in functorch limitations docs

### DIFF
--- a/functorch/docs/source/ux_limitations.rst
+++ b/functorch/docs/source/ux_limitations.rst
@@ -131,7 +131,7 @@ Tensor with fewer elements. Here's an example of how this can occur:
 
   def f(x, y):
     x.add_(y)
-  return x
+    return x
 
   x = torch.randn(1)
   y = torch.randn(3)


### PR DESCRIPTION
Fixes a minor indentation error in the `functorch` UX limitations documentation.